### PR TITLE
Configure Grafana with no-auth access and Tilt link

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -27,3 +27,6 @@ local_resource(
 )
 
 k8s_yaml(out_file)
+
+# --- links to services ---
+link('http://grafana.gudo11y.local', 'Grafana Dashboard')

--- a/tanka/environments/mop-central/grafana.jsonnet
+++ b/tanka/environments/mop-central/grafana.jsonnet
@@ -9,7 +9,22 @@ local common = import 'common.libsonnet';
     conf={
       namespace: common.namespace,
       values+: {
-
+        ingress+: {
+          enabled: true,
+          hosts: [
+            common.central.grafana_domain,
+          ],
+        },
+        // Disable authentication entirely
+        'grafana.ini'+: {
+          'auth.anonymous'+: {
+            enabled: true,
+            org_role: 'Admin',
+          },
+          auth+: {
+            disable_login_form: true,
+          },
+        },
       },
     }
   ),

--- a/tanka/environments/mop-cloud/kps.jsonnet
+++ b/tanka/environments/mop-cloud/kps.jsonnet
@@ -9,7 +9,25 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values: {
-
+        grafana+: {
+          enabled: true,
+          ingress+: {
+            enabled: true,
+            hosts: [
+              common.central.grafana_domain,
+            ],
+          },
+          // Disable authentication entirely
+          'grafana.ini'+: {
+            'auth.anonymous'+: {
+              enabled: true,
+              org_role: 'Admin',
+            },
+            auth+: {
+              disable_login_form: true,
+            },
+          },
+        },
       },
     }
   ),

--- a/tanka/environments/mop-edge/kps.jsonnet
+++ b/tanka/environments/mop-edge/kps.jsonnet
@@ -9,7 +9,25 @@ local common = import 'common.libsonnet';
     conf={
       namespace: common.namespace,
       values+: {
-
+        grafana+: {
+          enabled: true,
+          ingress+: {
+            enabled: true,
+            hosts: [
+              common.central.grafana_domain,
+            ],
+          },
+          // Disable authentication entirely
+          'grafana.ini'+: {
+            'auth.anonymous'+: {
+              enabled: true,
+              org_role: 'Admin',
+            },
+            auth+: {
+              disable_login_form: true,
+            },
+          },
+        },
       },
     }
   ),


### PR DESCRIPTION
## Summary
Configures Grafana across all environments to enable quick, authentication-free access during development with direct link integration in Tilt UI.

## Changes
- **Authentication**: Disabled login entirely via anonymous auth with Admin role
- **Ingress**: Enabled for all environments with `grafana.gudo11y.local` hostname  
- **Tilt Integration**: Added Grafana dashboard link in Tilt UI for one-click access

## Configuration Details

### Grafana Settings
```jsonnet
'grafana.ini'+: {
  'auth.anonymous'+: {
    enabled: true,
    org_role: 'Admin',
  },
  auth+: {
    disable_login_form: true,
  },
}
```

### Environments Updated
- ✅ **mop-central**: Standalone Grafana chart with ingress
- ✅ **mop-cloud**: kube-prometheus-stack Grafana with ingress  
- ✅ **mop-edge**: kube-prometheus-stack Grafana with ingress

### Tilt Link
Added `link('http://grafana.gudo11y.local', 'Grafana Dashboard')` to Tiltfile for easy access from Tilt UI.

## Access
Once deployed:
1. Start Tilt: `tilt up`
2. Click "Grafana Dashboard" link in Tilt UI
3. Access directly at http://grafana.gudo11y.local (no login required)

## Test Plan
- [x] Verified tk show generates valid manifests with auth.anonymous enabled
- [x] Confirmed ingress resources created with correct hostname
- [x] Tested Tiltfile syntax is valid
- [ ] Deploy to minikube and verify Grafana accessible without login
- [ ] Confirm Tilt link opens Grafana dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)