### PR TITLE
Fix missing linkerd namespace in all environments

### DIFF
--- a/tanka/environments/mop-central/config.jsonnet
+++ b/tanka/environments/mop-central/config.jsonnet
@@ -1,6 +1,12 @@
 local common = import 'common.libsonnet';
+local k = import 'k.libsonnet';
+
 {
   config: {
     namespace: common.namespace,
+    namespaces: [
+      k.core.v1.namespace.new(common.namespace),
+      k.core.v1.namespace.new('linkerd'),
+    ],
   },
 }

--- a/tanka/environments/mop-cloud/config.jsonnet
+++ b/tanka/environments/mop-cloud/config.jsonnet
@@ -1,6 +1,12 @@
 local common = import 'common.libsonnet';
+local k = import 'k.libsonnet';
+
 {
   config: {
     namespace: common.namespace,
+    namespaces: [
+      k.core.v1.namespace.new(common.namespace),
+      k.core.v1.namespace.new('linkerd'),
+    ],
   },
 }

--- a/tanka/environments/mop-edge/config.jsonnet
+++ b/tanka/environments/mop-edge/config.jsonnet
@@ -5,6 +5,7 @@ local k = import 'k.libsonnet';
   config:: {
     namespaces: [
       k.core.v1.namespace.new(common.namespace),
+      k.core.v1.namespace.new('linkerd'),
     ],
   },
 }


### PR DESCRIPTION
## Summary
Fixed missing linkerd namespace creation in all three environments (mop-central, mop-cloud, mop-edge) to prevent "namespace not found" errors when deploying Linkerd resources.

## Changes
- Updated `config.jsonnet` in all environments to create both 'mop' and 'linkerd' namespaces
- Resolves Tilt deployment errors for Linkerd proxy injector, destination, and other components

## Test plan
- [x] Applied changes locally
- [x] Verified Tilt deployment succeeds with both namespaces created
- [x] Confirmed all Linkerd resources deploy without namespace errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)