### PR TITLE
Initialize Tempo tracing in all environments

### DIFF
--- a/tanka/environments/mop-central/grafana.jsonnet
+++ b/tanka/environments/mop-central/grafana.jsonnet
@@ -46,6 +46,13 @@ local common = import 'common.libsonnet';
                   maxLines: 1000,
                 },
               },
+              {
+                name: 'Tempo',
+                type: 'tempo',
+                access: 'proxy',
+                url: 'http://tempo-query-frontend.monitoring.svc.cluster.local:3100',
+                isDefault: false,
+              },
             ],
           },
         },

--- a/tanka/environments/mop-central/tempo.jsonnet
+++ b/tanka/environments/mop-central/tempo.jsonnet
@@ -9,7 +9,25 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values+: {
-
+        traces: {
+          otlp: {
+            grpc: {
+              enabled: true,
+            },
+            http: {
+              enabled: true,
+            },
+          },
+        },
+        metricsGenerator: {
+          enabled: true,
+          remoteWriteUrl: 'http://prometheus-server.monitoring.svc.cluster.local/api/v1/write',
+        },
+        storage: {
+          trace: {
+            backend: 'local',
+          },
+        },
       },
     }
   ),

--- a/tanka/environments/mop-cloud/kps.jsonnet
+++ b/tanka/environments/mop-cloud/kps.jsonnet
@@ -38,6 +38,13 @@ local common = import 'common.libsonnet';
                 maxLines: 1000,
               },
             },
+            {
+              name: 'Tempo',
+              type: 'tempo',
+              access: 'proxy',
+              url: 'http://tempo.monitoring.svc.cluster.local:3100',
+              isDefault: false,
+            },
           ],
         },
       },

--- a/tanka/environments/mop-cloud/tempo.jsonnet
+++ b/tanka/environments/mop-cloud/tempo.jsonnet
@@ -9,7 +9,21 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values: {
-
+        tempo: {
+          searchEnabled: true,
+          metricsGenerator: {
+            enabled: true,
+            remoteWriteUrl: 'http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090/api/v1/write',
+          },
+          storage: {
+            trace: {
+              backend: 'local',
+              'local': {
+                path: '/var/tempo/traces',
+              },
+            },
+          },
+        },
       },
     }
   ),

--- a/tanka/environments/mop-edge/kps.jsonnet
+++ b/tanka/environments/mop-edge/kps.jsonnet
@@ -38,6 +38,13 @@ local common = import 'common.libsonnet';
                 maxLines: 1000,
               },
             },
+            {
+              name: 'Tempo',
+              type: 'tempo',
+              access: 'proxy',
+              url: 'http://tempo.%s.svc.cluster.local:3100' % common.namespace,
+              isDefault: false,
+            },
           ],
         },
       },

--- a/tanka/environments/mop-edge/main.jsonnet
+++ b/tanka/environments/mop-edge/main.jsonnet
@@ -13,9 +13,9 @@ local tempo = import 'tempo.jsonnet';
   eso: eso.eso,
   kps: kps.kps,
   loki: loki.loki,
+  tempo: tempo.tempo,
   alloy_operator: alloy_operator.alloy_operator,
   // alloy: alloy.alloy,
-  // tempo: tempo.tempo,
   linkerdCRDs: linkerd.linkerdCRDs,
   linkerdControlPlane: linkerd.linkerdControlPlane,
 }

--- a/tanka/environments/mop-edge/spec.json
+++ b/tanka/environments/mop-edge/spec.json
@@ -2,11 +2,11 @@
   "apiVersion": "tanka.dev/v1alpha1",
   "kind": "Environment",
   "metadata": {
-    "name": "minikube"
+    "name": "mop-edge"
   },
   "spec": {
     "contextNames": [
-      "minikube"
+      "orbstack"
     ],
     "namespace": "mop",
     "resourceDefaults": {},

--- a/tanka/environments/mop-edge/tempo.jsonnet
+++ b/tanka/environments/mop-edge/tempo.jsonnet
@@ -9,7 +9,21 @@ local common = import 'common.libsonnet';
     conf={
       namespace: common.namespace,
       values+: {
-
+        tempo: {
+          searchEnabled: true,
+          metricsGenerator: {
+            enabled: true,
+            remoteWriteUrl: 'http://kube-prometheus-stack-prometheus.%s.svc.cluster.local:9090/api/v1/write' % common.namespace,
+          },
+          storage: {
+            trace: {
+              backend: 'local',
+              'local': {
+                path: '/var/tempo/traces',
+              },
+            },
+          },
+        },
       },
     }
   ),


### PR DESCRIPTION
## Summary
Initializes Tempo distributed tracing backend across all three environments (mop-central, mop-cloud, mop-edge) with appropriate deployment modes and integrates with Grafana for trace visualization.

This PR adds comprehensive Tempo tracing support including:
- ✅ Tempo deployed to all environments with appropriate configurations
- ✅ Tempo datasource added to Grafana in all environments
- ✅ Metrics generator enabled to send RED metrics to Prometheus
- ✅ OTLP endpoints enabled for trace ingestion
- ✅ Search and query capabilities configured
- ✅ Updated mop-edge spec.json to use orbstack context

## Changes
- **mop-edge**: Deployed Tempo with local storage, metrics generator, and search enabled. Fixed spec.json context.
- **mop-cloud**: Deployed Tempo with local storage and metrics generator in monitoring namespace.
- **mop-central**: Deployed tempo-distributed with OTLP (gRPC/HTTP), metrics generator, and local storage.
- **Grafana Integration**: Added Tempo datasource in all Grafana instances for trace visualization.

## Features
- **OTLP Endpoints**: Accept traces via OpenTelemetry Protocol (gRPC & HTTP)
- **Metrics Generator**: Generates RED metrics (rate, errors, duration) from traces
- **Local Storage**: Filesystem-based trace storage for development
- **Search**: Query and search traces through Grafana or Tempo API
- **Integration**: Seamless integration with existing Prometheus and Grafana stack

## Test plan
- [x] Fixed Jsonnet syntax errors (reserved keyword 'local')
- [x] Vendored Helm charts for all environments
- [x] Updated mop-edge spec.json to use orbstack context
- [x] Deployed to mop-edge environment
- [x] Verified Tempo pod is running
- [x] Verified Tempo service is created with all required ports
- [x] Verified Tempo datasource is configured in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)