### PR TITLE
Initialize Mimir in mop-central with distributed mode

### DIFF
--- a/tanka/environments/mop-central/config.jsonnet
+++ b/tanka/environments/mop-central/config.jsonnet
@@ -2,8 +2,7 @@ local common = import 'common.libsonnet';
 local k = import 'k.libsonnet';
 
 {
-  config: {
-    namespace: common.namespace,
+  config:: {
     namespaces: [
       k.core.v1.namespace.new(common.namespace),
       k.core.v1.namespace.new('linkerd'),

--- a/tanka/environments/mop-central/grafana.jsonnet
+++ b/tanka/environments/mop-central/grafana.jsonnet
@@ -53,6 +53,13 @@ local common = import 'common.libsonnet';
                 url: 'http://tempo-query-frontend.monitoring.svc.cluster.local:3100',
                 isDefault: false,
               },
+              {
+                name: 'Mimir',
+                type: 'prometheus',
+                access: 'proxy',
+                url: 'http://mimir-query-frontend.monitoring.svc.cluster.local:8080/prometheus',
+                isDefault: false,
+              },
             ],
           },
         },

--- a/tanka/environments/mop-central/loki.jsonnet
+++ b/tanka/environments/mop-central/loki.jsonnet
@@ -9,11 +9,11 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values: {
-        deploymentMode: 'SimpleScalable',
+        deploymentMode: 'SingleBinary',
         loki: {
           auth_enabled: false,
           commonConfig: {
-            replication_factor: 2,
+            replication_factor: 1,
           },
           storage: {
             type: 'filesystem',
@@ -34,16 +34,16 @@ local common = import 'common.libsonnet';
           },
         },
         singleBinary: {
-          replicas: 0,
+          replicas: 1,
         },
         read: {
-          replicas: 2,
+          replicas: 0,
         },
         write: {
-          replicas: 2,
+          replicas: 0,
         },
         backend: {
-          replicas: 2,
+          replicas: 0,
         },
       },
     }

--- a/tanka/environments/mop-central/main.jsonnet
+++ b/tanka/environments/mop-central/main.jsonnet
@@ -4,14 +4,19 @@ local common = import 'common.libsonnet';
 local config = import 'config.jsonnet';
 local eso = import 'eso.jsonnet';
 local grafana = import 'grafana.jsonnet';
+local k = import 'k.libsonnet';
 local linkerd = import 'linkerd.jsonnet';
 local loki = import 'loki.jsonnet';
 local mimir = import 'mimir.jsonnet';
 local prometheus = import 'prometheus.jsonnet';
 local tempo = import 'tempo.jsonnet';
 
-{
-  config: config.config,
+config + {
+  namespaces: [
+    k.core.v1.namespace.new(common.namespace),
+    k.core.v1.namespace.new('linkerd'),
+    k.core.v1.namespace.new('monitoring'),
+  ],
   backstage: backstage.backstage,
   eso: eso.eso,
   grafana: grafana.grafana,

--- a/tanka/environments/mop-central/mimir.jsonnet
+++ b/tanka/environments/mop-central/mimir.jsonnet
@@ -9,7 +9,46 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values: {
-
+        mimir: {
+          structuredConfig: {
+            multitenancy_enabled: false,
+            ingester: {
+              ring: {
+                zone_awareness_enabled: false,
+              },
+            },
+            store_gateway: {
+              sharding_ring: {
+                zone_awareness_enabled: false,
+              },
+            },
+            usage_stats: {
+              enabled: false,
+            },
+          },
+        },
+        // Disable zone-aware replication at chart level
+        ingester: {
+          zoneAwareReplication: {
+            enabled: false,
+          },
+        },
+        store_gateway: {
+          zoneAwareReplication: {
+            enabled: false,
+          },
+        },
+        // Use distributed mode with separate components
+        minio: {
+          enabled: true,
+        },
+        // Use S3-compatible storage (MinIO) for distributed mode
+        backend: 's3',
+        metaMonitoring: {
+          serviceMonitor: {
+            enabled: true,
+          },
+        },
       },
     }
   ),

--- a/tanka/environments/mop-central/spec.json
+++ b/tanka/environments/mop-central/spec.json
@@ -2,13 +2,13 @@
   "apiVersion": "tanka.dev/v1alpha1",
   "kind": "Environment",
   "metadata": {
-    "name": "minikube"
+    "name": "mop-central"
   },
   "spec": {
     "contextNames": [
-      "minikube"
+      "orbstack"
     ],
-    "namespace": "default",
+    "namespace": "monitoring",
     "resourceDefaults": {},
     "expectVersions": {}
   }


### PR DESCRIPTION
## Summary
Initializes Grafana Mimir distributed metrics storage in mop-central environment with single-tenant mode and disabled zone-aware replication.

This PR adds comprehensive Mimir support including:
- ✅ Mimir deployed in distributed mode with separate components
- ✅ MinIO enabled for S3-compatible object storage
- ✅ Single-tenant mode (multitenancy disabled)
- ✅ Zone-aware replication disabled for ingester and store-gateway
- ✅ Mimir datasource added to Grafana
- ✅ ServiceMonitor integration for metrics collection

## Changes
- **Mimir**: Configured distributed deployment with multitenancy_enabled: false and zone_awareness_enabled: false for ingester/store-gateway
- **MinIO**: Enabled for local S3-compatible storage required by distributed mode
- **Grafana**: Added Mimir as Prometheus-compatible datasource
- **Infrastructure Fixes**:
  - Fixed config.jsonnet to use hidden field (::) preventing invalid K8s object error
  - Fixed Loki to use SingleBinary mode with filesystem storage
  - Updated spec.json to orbstack context with monitoring namespace
  - Added explicit monitoring namespace creation

## Architecture
Mimir distributed components deployed:
- **Distributor**: Receives metrics from Prometheus remote write
- **Ingester**: Stores metrics in memory and flushes to MinIO
- **Querier**: Queries metrics from ingesters and long-term storage
- **Query Frontend**: Provides query API and caching
- **Query Scheduler**: Manages query queuing and execution
- **Ruler**: Evaluates recording and alerting rules
- **Store Gateway**: Queries long-term storage blocks
- **Compactor**: Compacts and deduplicates blocks
- **MinIO**: S3-compatible object storage for blocks

## Test plan
- [x] Configured Mimir with distributed mode
- [x] Disabled multitenancy (single-tenant)
- [x] Disabled zone-aware replication
- [x] Enabled MinIO for S3-compatible storage
- [x] Added Mimir datasource to Grafana
- [x] Fixed config/spec issues for mop-central
- [x] Deployed to orbstack cluster
- [x] Verified 15+ Mimir pods running
- [x] Verified MinIO deployment
- [x] Verified query-frontend service available

🤖 Generated with [Claude Code](https://claude.com/claude-code)