### PR TITLE
Initialize Prometheus with remote write to central Mimir

### DIFF
--- a/tanka/environments/mop-cloud/kps.jsonnet
+++ b/tanka/environments/mop-cloud/kps.jsonnet
@@ -9,6 +9,28 @@ local common = import 'common.libsonnet';
     conf={
       namespace: 'monitoring',
       values: {
+        prometheus+: {
+          ingress+: {
+            enabled: true,
+            hosts: [
+              'prometheus-cloud.gudo11y.local',
+            ],
+          },
+          prometheusSpec+: {
+            remoteWrite: [
+              {
+                url: 'http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push',
+                writeRelabelConfigs: [
+                  {
+                    sourceLabels: ['__name__'],
+                    regex: '.*',
+                    action: 'keep',
+                  },
+                ],
+              },
+            ],
+          },
+        },
         grafana+: {
           enabled: true,
           ingress+: {

--- a/tanka/environments/mop-cloud/spec.json
+++ b/tanka/environments/mop-cloud/spec.json
@@ -2,13 +2,13 @@
   "apiVersion": "tanka.dev/v1alpha1",
   "kind": "Environment",
   "metadata": {
-    "name": "minikube"
+    "name": "mop-cloud"
   },
   "spec": {
     "contextNames": [
-      "minikube"
+      "orbstack"
     ],
-    "namespace": "default",
+    "namespace": "monitoring",
     "resourceDefaults": {},
     "expectVersions": {}
   }

--- a/tanka/environments/mop-edge/kps.jsonnet
+++ b/tanka/environments/mop-edge/kps.jsonnet
@@ -9,6 +9,28 @@ local common = import 'common.libsonnet';
     conf={
       namespace: common.namespace,
       values+: {
+        prometheus+: {
+          ingress+: {
+            enabled: true,
+            hosts: [
+              'prometheus-edge.gudo11y.local',
+            ],
+          },
+          prometheusSpec+: {
+            remoteWrite: [
+              {
+                url: 'http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push',
+                writeRelabelConfigs: [
+                  {
+                    sourceLabels: ['__name__'],
+                    regex: '.*',
+                    action: 'keep',
+                  },
+                ],
+              },
+            ],
+          },
+        },
         grafana+: {
           enabled: true,
           ingress+: {


### PR DESCRIPTION
## Summary
Configured Prometheus in mop-edge and mop-cloud environments to remote write metrics to the central Mimir instance for long-term storage and multi-tenancy support. Added ingress endpoints for direct Prometheus access in both environments.

## Changes
- **mop-edge**: Added Prometheus ingress (`prometheus-edge.gudo11y.local`) and remote write configuration to Mimir
- **mop-cloud**: Added Prometheus ingress (`prometheus-cloud.gudo11y.local`) and remote write configuration to Mimir
- **mop-cloud spec**: Updated `spec.json` to use orbstack context and monitoring namespace (previously minikube/default)
- **Remote Write**: Both environments configured to push metrics to `http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push`

## Architecture
Prometheus instances in edge and cloud environments now write metrics to the central Mimir instance, enabling:
- Centralized long-term metrics storage
- Unified querying across environments
- Reduced local storage requirements in edge/cloud
- Foundation for multi-tenant observability

## Test plan
- [x] Applied mop-edge configuration with `tk apply`
- [x] Verified Prometheus ingress created successfully
- [x] Verified prometheus-server pod is running
- [x] Confirmed remote write configuration in kps.jsonnet
- [ ] Verify metrics are flowing to Mimir (check Mimir ingester logs)
- [ ] Access Prometheus UI at prometheus-edge.gudo11y.local
- [ ] Query metrics in central Grafana from Mimir datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)