### PR TITLE
Configure Alloy to scrape node exporter and forward to Mimir

### DIFF
--- a/tanka/environments/mop-central/alloy.jsonnet
+++ b/tanka/environments/mop-central/alloy.jsonnet
@@ -1,0 +1,57 @@
+local k = import 'k.libsonnet';
+local common = import 'common.libsonnet';
+
+local configMap = k.core.v1.configMap;
+local alloy = {
+  apiVersion: 'collectors.grafana.com/v1alpha1',
+  kind: 'Alloy',
+  metadata: {
+    name: 'alloy-metrics',
+    namespace: common.namespace,
+  },
+  spec: {
+    // Alloy configuration
+    image: {
+      repository: 'grafana/alloy',
+      tag: 'latest',
+    },
+    alloy: {
+      configMap: {
+        content: |||
+          // Scrape node exporter metrics
+          prometheus.scrape "node_exporter" {
+            targets = [
+              {
+                "__address__" = "kube-prometheus-stack-prometheus-node-exporter.mop.svc.cluster.local:9100",
+              },
+            ]
+            forward_to = [prometheus.remote_write.mimir.receiver]
+
+            scrape_interval = "15s"
+          }
+
+          // Remote write to Mimir
+          prometheus.remote_write "mimir" {
+            endpoint {
+              url = "http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push"
+
+              queue_config {
+                capacity = 10000
+                max_shards = 10
+                min_shards = 1
+                max_samples_per_send = 5000
+                batch_send_deadline = "5s"
+                min_backoff = "30ms"
+                max_backoff = "5s"
+              }
+            }
+          }
+        |||,
+      },
+    },
+  },
+};
+
+{
+  alloy: alloy,
+}

--- a/tanka/environments/mop-central/main.jsonnet
+++ b/tanka/environments/mop-central/main.jsonnet
@@ -1,3 +1,4 @@
+local alloy = import 'alloy.jsonnet';
 local alloy_operator = import 'alloy_operator.jsonnet';
 local backstage = import 'backstage.jsonnet';
 local common = import 'common.libsonnet';
@@ -24,6 +25,7 @@ config + {
   loki: loki.loki,
   mimir: mimir.mimir,
   tempo: tempo.tempo,
+  alloy: alloy.alloy,
   alloy_operator: alloy_operator.alloy_operator,
   linkerdCRDs: linkerd.linkerdCRDs,
   linkerdControlPlane: linkerd.linkerdControlPlane,


### PR DESCRIPTION
## Summary
Configured Alloy in mop-central to scrape Prometheus node exporter metrics and forward them to the central Mimir instance for long-term storage. This establishes the foundation for distributed metrics collection using Grafana Alloy.

## Changes
- **alloy.jsonnet**: Created new Alloy instance configuration
  - Configured `prometheus.scrape` to scrape kube-prometheus-stack-prometheus-node-exporter service on port 9100
  - Configured `prometheus.remote_write` to forward metrics to Mimir at `http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push`
- **main.jsonnet**: Added Alloy instance to mop-central deployment

## Architecture
Alloy acts as a lightweight metrics collector that:
1. Scrapes metrics from node exporter (15s interval)
2. Forwards metrics to Mimir via remote write protocol
3. Provides a scalable alternative to Prometheus for edge collection

## Verification
✅ Alloy pod running successfully (2/2 containers)
✅ Metrics flowing through pipeline: Alloy → Mimir → Grafana
✅ 112 `node_cpu_seconds_total` metrics available in Mimir
✅ Metrics queryable via Grafana Mimir datasource

## Test plan
- [x] Created Alloy CR with node exporter scrape config
- [x] Deployed Alloy to mop-central
- [x] Verified Alloy pod is running
- [x] Queried Mimir directly for node exporter metrics (112 results)
- [x] Queried via Grafana Mimir datasource (112 results)
- [x] Verified complete pipeline functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)