### PR TITLE
Fix Tilt configuration issues

### DIFF
--- a/tanka/environments/mop-edge/tempo.jsonnet
+++ b/tanka/environments/mop-edge/tempo.jsonnet
@@ -18,7 +18,7 @@ local common = import 'common.libsonnet';
           storage: {
             trace: {
               backend: 'local',
-              'local': {
+              ['local']: {
                 path: '/var/tempo/traces',
               },
             },


### PR DESCRIPTION
## Summary
Fixed multiple Tilt configuration issues preventing `tilt up` from working.

## Changes
1. **Kubernetes Context Support**
   - Updated `allow_k8s_contexts` to support multiple contexts: `minikube`, `k3d-prod`, and `orbstack`
   - Previously only allowed `minikube`, blocking use with k3d cluster

2. **Tempo Jsonnet Syntax Fix**
   - Fixed `tempo.jsonnet` to use bracket notation `['local']` for reserved keyword
   - Resolves: `RUNTIME ERROR: Expected token IDENTIFIER but got (OPERATOR, ":")`

3. **Tilt Resource Management**
   - Changed from `k8s_yaml()` to `kubectl apply` pattern via `tk-apply` local resource
   - Avoids Tilt's strict YAML parsing while maintaining resource tracking
   - Added proper resource dependencies: `tk-apply` depends on `setup`
   - Configured `auto_init=True` and `TRIGGER_MODE_AUTO` for automatic updates

## Testing
- ✅ Tilt successfully loads without errors
- ✅ `tk-apply` resource executes and applies manifests
- ✅ Resources are properly tracked by Tilt
- ✅ File watching triggers reapplication on changes

## Notes
- CRD installation errors during initial apply are expected (need to be installed first)
- The setup script has a minor error about missing chartfile.yaml (pre-existing issue)
- Vendored charts are git-ignored, so template fixes are not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)