### PR TITLE
Fix kube-prometheus-stack CRD annotation size issues

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -19,13 +19,27 @@ local_resource(
     cmd= 'scripts/tilt_setup.sh'
 )
 
+# Install kube-prometheus-stack CRDs separately (for mop-edge and mop-cloud)
+# These CRDs have annotations that are too large for kubectl apply, so we install them with kubectl create --server-side
+if tk_env in ['mop-edge', 'mop-cloud']:
+    local_resource(
+        name='install-kps-crds',
+        cmd='kubectl apply --server-side -f tanka/environments/{tk_env}/charts/kube-prometheus-stack/charts/crds/crds/ || true'.format(tk_env=tk_env),
+        resource_deps=['setup'],
+        auto_init=True,
+        trigger_mode=TRIGGER_MODE_MANUAL,
+        labels=['kubernetes'],
+    )
+    tk_apply_deps = ['setup', 'install-kps-crds']
+else:
+    tk_apply_deps = ['setup']
 
 # Use local_resource to dynamically apply the Tanka-generated manifests
 local_resource(
     name='tk-apply',
     cmd='mkdir -p .tilt && tk show ./tanka/environments/{tk_env} --dangerous-allow-redirect > {out_file} && kubectl apply -f {out_file}'.format(tk_env=tk_env, out_file=out_file),
     deps=jsonnet_deps,
-    resource_deps=['setup'],
+    resource_deps=tk_apply_deps,
     auto_init=True,
     trigger_mode=TRIGGER_MODE_AUTO,
     labels=['kubernetes'],

--- a/tanka/environments/mop-cloud/kps.jsonnet
+++ b/tanka/environments/mop-cloud/kps.jsonnet
@@ -8,6 +8,8 @@ local common = import 'common.libsonnet';
     chart='./charts/kube-prometheus-stack',
     conf={
       namespace: 'monitoring',
+      noHooks: false,
+      includeCrds: false,
       values: {
         prometheus+: {
           ingress+: {

--- a/tanka/environments/mop-edge/kps.jsonnet
+++ b/tanka/environments/mop-edge/kps.jsonnet
@@ -8,6 +8,8 @@ local common = import 'common.libsonnet';
     chart='./charts/kube-prometheus-stack',
     conf={
       namespace: common.namespace,
+      noHooks: false,
+      includeCrds: false,
       values+: {
         prometheus+: {
           ingress+: {


### PR DESCRIPTION
## Problem
The kube-prometheus-stack CRDs have annotations exceeding 262144 bytes, causing kubectl apply to fail with "metadata.annotations: Too long" errors.

## Solution
1. **Skip CRD inclusion in helm template** - Added `includeCrds: false` to kps.jsonnet configuration for mop-edge and mop-cloud environments
2. **Install CRDs separately with server-side apply** - Added new Tiltfile step to install CRDs using `kubectl apply --server-side`, which handles large annotations properly
3. **Conditional CRD installation** - Only install CRDs for environments using kube-prometheus-stack (mop-edge, mop-cloud)

## Changes
- **tanka/environments/mop-edge/kps.jsonnet**: Added `includeCrds: false`
- **tanka/environments/mop-cloud/kps.jsonnet**: Added `includeCrds: false`
- **Tiltfile**: Added `install-kps-crds` resource to install CRDs before main tk-apply step

## Testing
- ✅ CRDs successfully installed with server-side apply
- ✅ Prometheus and Alertmanager resources created without errors
- ✅ All resources applying successfully in mop-edge environment
- ✅ No CRD annotation size errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)