### PR TITLE
Add Backstage and Grafana links to Tilt UI

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -48,5 +48,36 @@ local_resource(
 # Watch for changes in the generated YAML file to trigger reapplication
 watch_file(out_file)
 
-# --- links to services ---
-link('http://grafana.gudo11y.local', 'Grafana Dashboard')
+# --- UI links for services ---
+# Add Grafana to Tilt UI with port forward and link
+if tk_env == 'mop-central':
+    k8s_resource(
+        workload='grafana',
+        port_forwards='3001:80',
+        links=[
+            link('http://localhost:3001', 'Grafana (local)'),
+            link('http://grafana.gudo11y.local', 'Grafana (ingress)'),
+        ],
+        labels=['observability'],
+    )
+else:
+    k8s_resource(
+        workload='kube-prometheus-stack-grafana',
+        port_forwards='3001:80',
+        links=[
+            link('http://localhost:3001', 'Grafana (local)'),
+            link('http://grafana.gudo11y.local', 'Grafana (ingress)'),
+        ],
+        labels=['observability'],
+    )
+
+# Add Backstage to Tilt UI (only in mop-central)
+if tk_env == 'mop-central':
+    k8s_resource(
+        workload='backstage',
+        port_forwards='7007:7007',
+        links=[
+            link('http://localhost:7007', 'Backstage'),
+        ],
+        labels=['platform'],
+    )


### PR DESCRIPTION
## Summary
Adds Backstage and Grafana as visible resources in the Tilt UI with automatic port forwards and clickable links.

## Changes
- **Grafana resource**: Added for all environments (mop-central uses standalone grafana, others use kube-prometheus-stack-grafana)
  - Port forward: `3001:80`
  - Links: localhost and ingress URL
  - Label: `observability`

- **Backstage resource**: Added for mop-central environment only
  - Port forward: `7007:7007`
  - Link: localhost access
  - Label: `platform`

## Benefits
- ✅ Grafana and Backstage now appear as resources in Tilt UI
- ✅ One-click access to services from Tilt dashboard
- ✅ Port forwards automatically managed by Tilt
- ✅ Clear visibility of service health status
- ✅ Easy switching between local and ingress access

## Testing
To test, run `tilt up` and check that:
- Grafana appears in the UI with working port forward on localhost:3001
- Backstage appears in the UI (mop-central only) with working port forward on localhost:7007
- Links are clickable and work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)