### PR TITLE
Fix Tiltfile to use k8s_yaml for resource tracking

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -34,16 +34,19 @@ if tk_env in ['mop-edge', 'mop-cloud']:
 else:
     tk_apply_deps = ['setup']
 
-# Use local_resource to dynamically apply the Tanka-generated manifests
+# Generate Tanka manifests and load them into Tilt
 local_resource(
-    name='tk-apply',
-    cmd='mkdir -p .tilt && tk show ./tanka/environments/{tk_env} --dangerous-allow-redirect > {out_file} && kubectl apply -f {out_file}'.format(tk_env=tk_env, out_file=out_file),
+    name='tk-render',
+    cmd='mkdir -p .tilt && tk show ./tanka/environments/{tk_env} --dangerous-allow-redirect > {out_file}'.format(tk_env=tk_env, out_file=out_file),
     deps=jsonnet_deps,
     resource_deps=tk_apply_deps,
     auto_init=True,
     trigger_mode=TRIGGER_MODE_AUTO,
     labels=['kubernetes'],
 )
+
+# Load the generated YAML so Tilt tracks the resources
+k8s_yaml(out_file)
 
 # Watch for changes in the generated YAML file to trigger reapplication
 watch_file(out_file)


### PR DESCRIPTION
## Problem
The previous Tilt configuration used `kubectl apply` in a local_resource, which meant Tilt didn't track individual Kubernetes resources. This caused `k8s_resource` calls to fail with "unknown resource" errors, breaking the Tilt UI links feature.

## Solution
Changed from `kubectl apply` to using `k8s_yaml()` to load the generated manifests. This allows Tilt to track all Kubernetes resources, enabling `k8s_resource()` configurations for port forwards and links to work properly.

## Changes
- **Renamed** `tk-apply` to `tk-render` (focuses on YAML generation only)
- **Removed** `kubectl apply` from the command (Tilt now handles deployment automatically)
- **Added** `k8s_yaml(out_file)` to load manifests into Tilt for resource tracking
- Now Tilt properly tracks all Kubernetes workloads

## Benefits
- ✅ Tilt UI shows all deployed resources with proper status
- ✅ `k8s_resource()` configurations work correctly  
- ✅ Port forwards and links function as intended
- ✅ Better visibility into deployment status and logs
- ✅ Grafana and Backstage links now appear in Tilt UI

## Testing
Verified that:
- Tiltfile loads without errors
- Resources are properly tracked and displayed in Tilt UI
- Port forwards work correctly
- Links are clickable and functional

Fixes #15 (Backstage and Grafana links feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)